### PR TITLE
Switch from pip v1 to official AWS CLI v2 installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ansible-role-awscli
 ===================
 
-This role installs and configures [AWS Command Line Interface](https://aws.amazon.com/cli/).
+This role installs and configures [AWS Command Line Interface v2](https://aws.amazon.com/cli/) using the [official AWS installer](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
 Requirements
 ------------

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -1,32 +1,10 @@
 import pytest
 
 
-@pytest.mark.parametrize(
-    "package",
-    [
-        "python3-pip",
-    ],
-)
-def test_dependencies_installed(host, package):
-    pkg = host.package(package)
-    assert pkg.is_installed
-
-
-@pytest.mark.parametrize(
-    "name",
-    [
-        ("awscli"),
-    ],
-)
-def test_awscli_is_installed(host, name):
-    packages = host.pip.get_packages(pip_path="pip3")
-    assert name in packages
-
-
-def test_awscli_command_works(host):
-    cmd = host.run("aws --version")
+def test_awscli_is_installed(host):
+    cmd = host.run("/usr/local/bin/aws --version")
     assert cmd.rc == 0
-    assert "aws-cli" in cmd.stdout or "aws-cli" in cmd.stderr
+    assert "aws-cli/2" in cmd.stdout or "aws-cli/2" in cmd.stderr
 
 
 @pytest.mark.parametrize(

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
   block:
     - name: Determine architecture
       ansible.builtin.set_fact:
-        _awscli_arch: "{{ 'aarch64' if ansible_architecture == 'aarch64' else 'x86_64' }}"
+        _awscli_arch: "{{ 'aarch64' if ansible_facts['architecture'] == 'aarch64' else 'x86_64' }}"
 
     - name: Download aws cli v2
       ansible.builtin.unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,37 @@
 ---
-- name: Ensure awscli package is not installed
+- name: Ensure unzip is installed
   ansible.builtin.package:
-    name: awscli
-    state: absent
-
-- name: Ensure pip is installed
-  ansible.builtin.package:
-    name: python3-pip
+    name: unzip
     state: present
     update_cache: true
 
-- name: Ensure awscli python package is installed
-  ansible.builtin.pip:
-    break_system_packages: true
-    name: awscli
-    state: "{{ awscli_package_state }}"
+- name: Check if aws cli is installed
+  ansible.builtin.command: /usr/local/bin/aws --version
+  register: _awscli_version
+  changed_when: false
+  failed_when: false
+
+- name: Download and install aws cli v2
+  when: _awscli_version.rc != 0 or awscli_package_state == 'latest'
+  block:
+    - name: Determine architecture
+      ansible.builtin.set_fact:
+        _awscli_arch: "{{ 'aarch64' if ansible_architecture == 'aarch64' else 'x86_64' }}"
+
+    - name: Download aws cli v2
+      ansible.builtin.unarchive:
+        src: "https://awscli.amazonaws.com/awscli-exe-linux-{{ _awscli_arch }}.zip"
+        dest: /tmp
+        remote_src: true
+
+    - name: Install aws cli v2
+      ansible.builtin.command: /tmp/aws/install --update
+      changed_when: true
+
+    - name: Remove installer files
+      ansible.builtin.file:
+        path: /tmp/aws
+        state: absent
 
 - name: Ensure ~/.aws directory exists
   ansible.builtin.file:


### PR DESCRIPTION
## Summary

- Replace pip-based installation of awscli v1 with the official AWS CLI v2 installer
- Supports both x86_64 and aarch64 architectures
- No longer requires pip on target hosts

## Test plan

- [x] Run `molecule test` on all platforms (Debian 12, 13, Ubuntu 22.04, 24.04)
- [x] Verify `aws --version` returns `aws-cli/2.x`
- [x] Test upgrade path with `awscli_package_state: latest`